### PR TITLE
CMSIS-compatible ARM Cortex-M ports

### DIFF
--- a/Ports/ARM-Cortex-M/ARMv6-M/ARM/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv6-M/ARM/os_cpu.h
@@ -12,6 +12,13 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -183,8 +190,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U  cnts);
 void       OS_CPU_SysTickInitFreq (INT32U  cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 
 /*

--- a/Ports/ARM-Cortex-M/ARMv6-M/ARM/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv6-M/ARM/os_cpu_a.asm
@@ -51,7 +51,7 @@
     EXPORT  OS_CPU_SR_Restore
     EXPORT  OSCtxSw
     EXPORT  OSIntCtxSw
-    EXPORT  OS_CPU_PendSVHandler
+    EXPORT  PendSV_Handler  ; QL was: OS_CPU_PendSVHandler
 
 
 ;********************************************************************************************************

--- a/Ports/ARM-Cortex-M/ARMv6-M/ARM/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv6-M/ARM/os_cpu_a.asm
@@ -11,6 +11,12 @@
 ;                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 ;
 ;********************************************************************************************************
+; Modified from the original to interoperate with CMIS as follows:
+; - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+;
+; Quantum Leaps, LLC. www.state-machine.com
+; 2020-06-01
+;********************************************************************************************************
 
 ;********************************************************************************************************
 ;
@@ -220,7 +226,7 @@ OSIntCtxSw
 ;              therefore safe to assume that context being switched out was using the process stack (PSP).
 ;********************************************************************************************************
 
-OS_CPU_PendSVHandler
+PendSV_Handler    ; QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   ; Prevent interruption during context switch
     MRS     R0, PSP                                             ; PSP is process stack pointer
 

--- a/Ports/ARM-Cortex-M/ARMv6-M/GNU/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv6-M/GNU/os_cpu.h
@@ -12,6 +12,13 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -183,8 +190,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U  cnts);
 void       OS_CPU_SysTickInitFreq (INT32U  cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 
 /*

--- a/Ports/ARM-Cortex-M/ARMv6-M/GNU/os_cpu_a.s
+++ b/Ports/ARM-Cortex-M/ARMv6-M/GNU/os_cpu_a.s
@@ -11,6 +11,12 @@
 @                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 @
 @********************************************************************************************************
+@ Modified from the original to interoperate with CMIS as follows:
+@ - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+@
+@ Quantum Leaps, LLC. www.state-machine.com
+@ 2020-06-01
+@********************************************************************************************************
 
 @********************************************************************************************************
 @
@@ -226,7 +232,7 @@ OSIntCtxSw:
 @********************************************************************************************************
 
 .thumb_func
-OS_CPU_PendSVHandler:
+PendSV_Handler:  @ QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   @ Prevent interruption during context switch
     MRS     R0, PSP                                             @ PSP is process stack pointer
 

--- a/Ports/ARM-Cortex-M/ARMv6-M/GNU/os_cpu_a.s
+++ b/Ports/ARM-Cortex-M/ARMv6-M/GNU/os_cpu_a.s
@@ -51,7 +51,7 @@
     .global  OS_CPU_SR_Restore
     .global  OSCtxSw
     .global  OSIntCtxSw
-    .global  OS_CPU_PendSVHandler
+    .global  PendSV_Handler  @ QL was: OS_CPU_PendSVHandler
 
 
 @********************************************************************************************************
@@ -238,7 +238,7 @@ PendSV_Handler:  @ QL was: OS_CPU_PendSVHandler
 
     CMP     R0, #0
     BEQ     OS_CPU_PendSVHandler_nosave                         @ equivalent code to CBZ from M3 arch to M0 arch
-																@ Except that it does not change the condition code flags
+                                                                @ Except that it does not change the condition code flags
 
     SUBS    R0, R0, #0x24                                       @ Adjust SP to make space for Low, High & LR registers
     LDR     R1, =OSTCBCur                                       @ OSTCBCur->OSTCBStkPtr = SP;

--- a/Ports/ARM-Cortex-M/ARMv6-M/IAR/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv6-M/IAR/os_cpu.h
@@ -12,6 +12,13 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -183,8 +190,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U  cnts);
 void       OS_CPU_SysTickInitFreq (INT32U  cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 
 /*

--- a/Ports/ARM-Cortex-M/ARMv6-M/IAR/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv6-M/IAR/os_cpu_a.asm
@@ -51,7 +51,7 @@
     PUBLIC  OS_CPU_SR_Restore
     PUBLIC  OSCtxSw
     PUBLIC  OSIntCtxSw
-    PUBLIC  OS_CPU_PendSVHandler
+    PUBLIC  PendSV_Handler ; QL was: OS_CPU_PendSVHandler
 
 
 ;********************************************************************************************************

--- a/Ports/ARM-Cortex-M/ARMv6-M/IAR/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv6-M/IAR/os_cpu_a.asm
@@ -11,6 +11,12 @@
 ;                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 ;
 ;********************************************************************************************************
+; Modified from the original to interoperate with CMIS as follows:
+; - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+;
+; Quantum Leaps, LLC. www.state-machine.com
+; 2020-06-01
+;********************************************************************************************************
 
 ;********************************************************************************************************
 ;
@@ -219,7 +225,7 @@ OSIntCtxSw
 ;              therefore safe to assume that context being switched out was using the process stack (PSP).
 ;********************************************************************************************************
 
-OS_CPU_PendSVHandler
+PendSV_Handler  ; QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   ; Prevent interruption during context switch
     MRS     R0, PSP                                             ; PSP is process stack pointer
 

--- a/Ports/ARM-Cortex-M/ARMv6-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv6-M/os_cpu_c.c
@@ -12,6 +12,12 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -465,7 +471,7 @@ void  OSTimeTickHook (void)
 *********************************************************************************************************
 */
 
-void  OS_CPU_SysTickHandler (void)
+void SysTick_Handler (void) /* QL was: void  OS_CPU_SysTickHandler (void) */
 {
 #if OS_CRITICAL_METHOD == 3u                                    /* Allocate storage for CPU status register             */
     OS_CPU_SR  cpu_sr;

--- a/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu.h
@@ -12,6 +12,13 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -208,8 +215,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U     cnts);
 void       OS_CPU_SysTickInitFreq (INT32U     cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 #if (OS_CPU_ARM_FP_EN > 0u)
 void       OS_CPU_FP_Reg_Push     (OS_STK    *stkPtr);

--- a/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv7-M/ARM/os_cpu_a.asm
@@ -11,6 +11,12 @@
 ;                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 ;
 ;********************************************************************************************************
+; Modified from the original to interoperate with CMIS as follows:
+; - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+;
+; Quantum Leaps, LLC. www.state-machine.com
+; 2020-06-01
+;********************************************************************************************************
 
 ;********************************************************************************************************
 ;
@@ -49,7 +55,7 @@
     EXPORT  OS_CPU_SR_Restore
     EXPORT  OSCtxSw
     EXPORT  OSIntCtxSw
-    EXPORT  OS_CPU_PendSVHandler
+    EXPORT  PendSV_Handler ; QL was: OS_CPU_PendSVHandler
 
     IF {FPU} != "SoftVFP"
     EXPORT  OS_CPU_FP_Reg_Push
@@ -326,7 +332,7 @@ OSIntCtxSw
 ;                  CPSIE i
 ;********************************************************************************************************
 
-OS_CPU_PendSVHandler
+PendSV_Handler    ; QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   ; Cortex-M7 errata notice. See Note #5
     MOV32   R2, OS_KA_BASEPRI_Boundary                          ; Set BASEPRI priority level required for exception preemption
     LDR     R1, [R2]

--- a/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu.h
@@ -12,6 +12,13 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -208,8 +215,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U     cnts);
 void       OS_CPU_SysTickInitFreq (INT32U     cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 #if (OS_CPU_ARM_FP_EN > 0u)
 void       OS_CPU_FP_Reg_Push     (OS_STK    *stkPtr);

--- a/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu_a.asm
@@ -11,6 +11,12 @@
 ;                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 ;
 ;********************************************************************************************************
+; Modified from the original to interoperate with CMIS as follows:
+; - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+;
+; Quantum Leaps, LLC. www.state-machine.com
+; 2020-06-01
+;********************************************************************************************************
 
 ;********************************************************************************************************
 ;
@@ -347,7 +353,7 @@ OSIntCtxSw:
 ;********************************************************************************************************
 
     .asmfunc
-OS_CPU_PendSVHandler:
+PendSV_Handler:   ; QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   ; Cortex-M7 errata notice. See Note #5
     LDR     R2, OS_KA_BASEPRI_BoundaryAddr                      ; Set BASEPRI priority level required for exception preemption
     LDR     R1, [R2]

--- a/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv7-M/CCS/os_cpu_a.asm
@@ -65,7 +65,7 @@ OS_KA_BASEPRI_BoundaryAddr:  .word  OS_KA_BASEPRI_Boundary
     .global  OS_CPU_SR_Restore
     .global  OSCtxSw
     .global  OSIntCtxSw
-    .global  OS_CPU_PendSVHandler
+    .global  PendSV_Handler ; QL was: OS_CPU_PendSVHandler
 
     .if __TI_VFP_SUPPORT__
     .global  OS_CPU_FP_Reg_Push

--- a/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu.h
@@ -12,7 +12,15 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
+
 
 /*
 *********************************************************************************************************
@@ -208,8 +216,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U     cnts);
 void       OS_CPU_SysTickInitFreq (INT32U     cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 #if (OS_CPU_ARM_FP_EN > 0u)
 void       OS_CPU_FP_Reg_Push     (OS_STK    *stkPtr);

--- a/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu_a.S
+++ b/Ports/ARM-Cortex-M/ARMv7-M/GNU/os_cpu_a.S
@@ -11,6 +11,12 @@
 @                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 @
 @********************************************************************************************************
+@ Modified from the original to interoperate with CMIS as follows:
+@ - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+@
+@ Quantum Leaps, LLC. www.state-machine.com
+@ 2020-06-01
+@********************************************************************************************************
 
 @********************************************************************************************************
 @
@@ -49,7 +55,7 @@
     .global  OS_CPU_SR_Restore
     .global  OSCtxSw
     .global  OSIntCtxSw
-    .global  OS_CPU_PendSVHandler
+    .global  PendSV_Handler  @ QL was: OS_CPU_PendSVHandler
 
 #if (defined(__VFP_FP__) && !defined(__SOFTFP__))
     .global  OS_CPU_FP_Reg_Push
@@ -339,7 +345,7 @@ OSIntCtxSw:
 @********************************************************************************************************
 
 .thumb_func
-OS_CPU_PendSVHandler:
+PendSV_Handler:  @ QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   @ Cortex-M7 errata notice. See Note #5
     MOVW    R2, #:lower16:OS_KA_BASEPRI_Boundary                @ Set BASEPRI priority level required for exception preemption
     MOVT    R2, #:upper16:OS_KA_BASEPRI_Boundary

--- a/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu.h
+++ b/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu.h
@@ -12,7 +12,15 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
+
 
 /*
 *********************************************************************************************************
@@ -208,8 +216,8 @@ void       OSStartHighRdy         (void);
 void       OS_CPU_SysTickInit     (INT32U     cnts);
 void       OS_CPU_SysTickInitFreq (INT32U     cpu_freq);
 
-void       OS_CPU_SysTickHandler  (void);
-void       OS_CPU_PendSVHandler   (void);
+void       SysTick_Handler        (void);  /* QL was: OS_CPU_SysTickHandler  (void); */
+void       PendSV_Handler         (void);  /* QL was: OS_CPU_PendSVHandler   (void); */
 
 #if (OS_CPU_ARM_FP_EN > 0u)
 void       OS_CPU_FP_Reg_Push     (OS_STK    *stkPtr);

--- a/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu_a.asm
+++ b/Ports/ARM-Cortex-M/ARMv7-M/IAR/os_cpu_a.asm
@@ -11,6 +11,12 @@
 ;                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 ;
 ;********************************************************************************************************
+; Modified from the original to interoperate with CMIS as follows:
+; - renamed OS_CPU_PendSVHandler to CMSIS-compatible name PendSV_Handler
+;
+; Quantum Leaps, LLC. www.state-machine.com
+; 2020-06-01
+;********************************************************************************************************
 
 ;********************************************************************************************************
 ;
@@ -49,7 +55,7 @@
     PUBLIC  OS_CPU_SR_Restore
     PUBLIC  OSCtxSw
     PUBLIC  OSIntCtxSw
-    PUBLIC  OS_CPU_PendSVHandler
+    PUBLIC  PendSV_Handler  ; QL was: OS_CPU_PendSVHandler
 
 #ifdef __ARMVFP__
     PUBLIC  OS_CPU_FP_Reg_Push
@@ -320,7 +326,7 @@ OSIntCtxSw
 ;                  CPSIE i
 ;********************************************************************************************************
 
-OS_CPU_PendSVHandler
+PendSV_Handler  ; QL was: OS_CPU_PendSVHandler
     CPSID   I                                                   ; Cortex-M7 errata notice. See Note #5
     MOV32   R2, OS_KA_BASEPRI_Boundary                          ; Set BASEPRI priority level required for exception preemption
     LDR     R1, [R2]

--- a/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
@@ -12,6 +12,12 @@
 *                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
 *
 *********************************************************************************************************
+*
+* Modified from the original to interoperate with CMIS as follows:
+* - renamed OS_CPU_SysTickHandler to CMSIS-compatible name SysTick_Handler
+*
+* Quantum Leaps, LLC. www.state-machine.com
+* 2020-06-01
 */
 
 /*
@@ -647,7 +653,7 @@ void  OSTimeTickHook (void)
 *********************************************************************************************************
 */
 
-void  OS_CPU_SysTickHandler (void)
+void SysTick_Handler (void) /* QL was: void  OS_CPU_SysTickHandler (void) */
 {
 #if OS_CRITICAL_METHOD == 3u                                    /* Allocate storage for CPU status register             */
     OS_CPU_SR  cpu_sr;

--- a/readme.md
+++ b/readme.md
@@ -4,3 +4,8 @@
 Offering unprecedented ease-of-use, μC/OS-II is delivered with complete 100% ANSI C source code and in-depth documentation. μC/OS-II runs on the largest number of processor architectures, with ports available for download from the Micrium Web site.
 
 ## For the complete documentation, visit https://doc.micrium.com/display/ucos/
+
+---------------
+# Modifications
+The ARM Cortex-M ports (Ports/ARM-Cortex-M directory) have been modified to comply with CMSIS. Specifically, the PendSV and SysTick exception handlers have been renamed to the CMSIS-compliant names PendSV_Handler (originally was OS_CPU_PendSVHandler) and SysTick_Handler (originally was OS_CPU_SysTickHandler). This change is necessary for the uC/OS-II applications to be able to use the CMSIS-compliant startup code.
+     


### PR DESCRIPTION
The ARM Cortex-M ports (Ports/ARM-Cortex-M directory) have been modified to comply with CMSIS. Specifically, the PendSV and SysTick exception handlers have been renamed to the CMSIS-compliant names PendSV_Handler (originally was OS_CPU_PendSVHandler) and SysTick_Handler (originally was OS_CPU_SysTickHandler). This change is necessary for the uC/OS-II applications to be able to use the CMSIS-compliant startup code.