### PR TITLE
Make the name of the events a pointer to constant.

### DIFF
--- a/Source/os_core.c
+++ b/Source/os_core.c
@@ -114,9 +114,9 @@ static  void  OS_SchedNew(void);
 */
 
 #if (OS_EVENT_EN) && (OS_EVENT_NAME_EN > 0u)
-INT8U  OSEventNameGet (OS_EVENT   *pevent,
-                       INT8U     **pname,
-                       INT8U      *perr)
+INT8U  OSEventNameGet (OS_EVENT      *pevent,
+                       const INT8U  **pname,
+                       INT8U         *perr)
 {
     INT8U      len;
 #if OS_CRITICAL_METHOD == 3u                     /* Allocate storage for CPU status register           */
@@ -137,7 +137,7 @@ INT8U  OSEventNameGet (OS_EVENT   *pevent,
         *perr = OS_ERR_PEVENT_NULL;
         return (0u);
     }
-    if (pname == (INT8U **)0) {                   /* Is 'pname' a NULL pointer?                         */
+    if (pname == (const INT8U **)0) {                   /* Is 'pname' a NULL pointer?                         */
         *perr = OS_ERR_PNAME_NULL;
         return (0u);
     }
@@ -194,9 +194,9 @@ INT8U  OSEventNameGet (OS_EVENT   *pevent,
 */
 
 #if (OS_EVENT_EN) && (OS_EVENT_NAME_EN > 0u)
-void  OSEventNameSet (OS_EVENT  *pevent,
-                      INT8U     *pname,
-                      INT8U     *perr)
+void  OSEventNameSet (OS_EVENT       *pevent,
+                      const INT8U    *pname,
+                      INT8U          *perr)
 {
 #if OS_CRITICAL_METHOD == 3u                     /* Allocate storage for CPU status register           */
     OS_CPU_SR  cpu_sr = 0u;
@@ -1793,13 +1793,13 @@ static  void  OS_SchedNew (void)
 */
 
 #if (OS_EVENT_NAME_EN > 0u) || (OS_FLAG_NAME_EN > 0u) || (OS_MEM_NAME_EN > 0u) || (OS_TASK_NAME_EN > 0u) || (OS_TMR_CFG_NAME_EN > 0u)
-INT8U  OS_StrLen (INT8U *psrc)
+INT8U  OS_StrLen (const INT8U *psrc)
 {
     INT8U  len;
 
 
 #if OS_ARG_CHK_EN > 0u
-    if (psrc == (INT8U *)0) {
+    if (psrc == (const INT8U *)0) {
         return (0u);
     }
 #endif

--- a/Source/ucos_ii.h
+++ b/Source/ucos_ii.h
@@ -383,7 +383,7 @@ typedef struct os_event {
     OS_PRIO  OSEventTbl[OS_EVENT_TBL_SIZE]; /* List of tasks waiting for event to occur                */
 
 #if OS_EVENT_NAME_EN > 0u
-    INT8U   *OSEventName;
+    const INT8U *OSEventName;
 #endif
 } OS_EVENT;
 #endif
@@ -795,11 +795,11 @@ extern  INT8U   const     OSUnMapTbl[256];          /* Priority->Index    lookup
 
 #if (OS_EVENT_NAME_EN > 0u)
 INT8U         OSEventNameGet          (OS_EVENT        *pevent,
-                                       INT8U          **pname,
+                                       const INT8U    **pname,
                                        INT8U           *perr);
 
 void          OSEventNameSet          (OS_EVENT        *pevent,
-                                       INT8U           *pname,
+                                       const INT8U     *pname,
                                        INT8U           *perr);
 #endif
 
@@ -1346,7 +1346,7 @@ void          OS_QInit                (void);
 void          OS_Sched                (void);
 
 #if (OS_EVENT_NAME_EN > 0u) || (OS_FLAG_NAME_EN > 0u) || (OS_MEM_NAME_EN > 0u) || (OS_TASK_NAME_EN > 0u)
-INT8U         OS_StrLen               (INT8U           *psrc);
+INT8U         OS_StrLen               (const INT8U     *psrc);
 #endif
 
 void          OS_TaskIdle             (void            *p_arg);


### PR DESCRIPTION
This avoids undefined behavior when casting the const attribute away. Compiler warnings are also avoided.